### PR TITLE
Reduce descriptions to 300 weight and lighter gray

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -66,6 +66,12 @@ module.exports = function (eleventyConfig) {
             weight: 400,
             style: 'normal',
           },
+          {
+            name: 'Faustina',
+            data: fs.readFileSync('./node_modules/@fontsource/faustina/files/faustina-all-300-normal.woff'),
+            weight: 300,
+            style: 'normal',
+          },
         ],
       },
     })
@@ -95,7 +101,7 @@ module.exports = function (eleventyConfig) {
 
     eleventyConfig.addPassthroughCopy({ "./src/_static/*" : "/" });
     eleventyConfig.addPassthroughCopy({ './node_modules/@fontsource/figtree/files/*latin-{400,700}*.woff2': '/css/files' })
-    eleventyConfig.addPassthroughCopy({ './node_modules/@fontsource/faustina/files/*latin-{400,700}*.woff2': '/css/files' })
+    eleventyConfig.addPassthroughCopy({ './node_modules/@fontsource/faustina/files/*latin-{300,400,700}*.woff2': '/css/files' })
 
     eleventyConfig.addWatchTarget("./src/sass/");
 

--- a/src/sass/components.scss
+++ b/src/sass/components.scss
@@ -53,10 +53,12 @@
     }
 }
 .post-description {
+    font-weight: 300;
     line-height: 1.3;
-    font-size: 1.75em;
-    margin-top: 2rem;
-    margin-bottom: 2rem;
+    font-size: 1.65em;
+    margin-top: 1.6rem;
+    margin-bottom: 1.6rem;
+    color: var(--color-gray-11);
 }
 .article-content {
     margin-bottom: 3rem;

--- a/src/sass/tokens/fonts.scss
+++ b/src/sass/tokens/fonts.scss
@@ -3,6 +3,7 @@
 @import '../../../node_modules/@fontsource/figtree/700';
 @import '../../../node_modules/@fontsource/figtree/700-italic';
 
+@import '../../../node_modules/@fontsource/faustina/300';
 @import '../../../node_modules/@fontsource/faustina/400';
 @import '../../../node_modules/@fontsource/faustina/400-italic';
 @import '../../../node_modules/@fontsource/faustina/700';


### PR DESCRIPTION
The descriptions on pages like About kept looking like the page title to me. I want the description to stand out less than the title and other headings do, and to have about the same visual weight as the body font.