### PR TITLE
Only deploy when needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,47 +16,28 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Get changed files
-        id: changed-files
+        id: changed_files
         uses: tj-actions/changed-files@v35
 
       - name: Check for non-Markdown files
         id: check_files
         run: |
-          non_markdown_files=$(echo "${{ steps.changed-files.outputs.modified_files }}" | grep -v '\.md$' || true)
+          non_markdown_files=$(echo "${{ steps.changed_files.outputs.modified_files }}" | grep -v '\.md$' || true)
           echo "non_markdown_files=$non_markdown_files" >> $GITHUB_OUTPUT
 
       - name: Build site
+        id: build_site
         run: |
           if [[ "${{ github.event_name }}" == "schedule" || -n "${{ steps.check_files.outputs.non_markdown_files }}" ]]; then
             npm install
             npm run build
+            echo "outcome=success" >> $GITHUB_OUTPUT
           else
             echo "Skipping build step."
           fi
 
-      - name: Archive build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-artifacts
-          path: ./dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    if: needs.build.result == 'success'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: build-artifacts
-          path: ./dist
-
       - name: Deploy to Netlify
+        if: steps.build_site.outcome == 'success'
         uses: nwtgck/actions-netlify@v2.0
         with:
           publish-dir: "./dist"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - only-deploy-when-needed
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,44 @@
 name: Build and Deploy to Netlify
+
 on:
   schedule:
-    - cron:  "0 15 * * *"
+    - cron: "0 15 * * *"
   push:
+    branches:
+      - main
+
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-          
-      - name: Build site
-        working-directory: ./
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+
+      - name: Check for non-Markdown files
+        id: check_files
         run: |
-          npm install
-          npm run build
+          non_markdown_files=$(echo "${{ steps.changed-files.outputs.modified_files }}" | grep -v '\.md$' || true)
+          echo "non_markdown_files=$non_markdown_files" >> $GITHUB_OUTPUT
+
+      - name: Build site
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" || -n "${{ steps.check_files.outputs.non_markdown_files }}" ]]; then
+            npm install
+            npm run build
+          else
+            echo "Skipping build step."
+          fi
 
       - name: Deploy to Netlify
+        if: steps.build.outcome == 'success'
         uses: nwtgck/actions-netlify@v2.0
         with:
-          publish-dir: './dist'
+          publish-dir: "./dist"
           netlify-config-path: ./netlify.toml
           production-branch: main
           production-deploy: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,17 @@ jobs:
           else
             echo "Skipping build step."
           fi
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    if: needs.build.result == 'success'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Deploy to Netlify
-        if: steps.build.outcome == 'success'
         uses: nwtgck/actions-netlify@v2.0
         with:
           publish-dir: "./dist"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,14 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" || -n "${{ steps.check_files.outputs.non_markdown_files }}" ]]; then
             npm install
             npm run build
-            echo "outcome=success" >> $GITHUB_OUTPUT
+            echo "result=built" >> $GITHUB_OUTPUT
           else
             echo "Skipping build step."
+            echo "result=skipped" >> $GITHUB_OUTPUT
           fi
 
       - name: Deploy to Netlify
-        if: steps.build_site.outcome == 'success'
+        if: steps.build_site.outputs.result == 'built'
         uses: nwtgck/actions-netlify@v2.0
         with:
           publish-dir: "./dist"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,13 @@ jobs:
           else
             echo "Skipping build step."
           fi
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: ./dist
+
   deploy:
     needs: build
     runs-on: ubuntu-latest
@@ -42,6 +49,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifacts
+          path: ./dist
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v2.0

--- a/src/en/colophon.md
+++ b/src/en/colophon.md
@@ -8,7 +8,8 @@ eleventyExcludeFromCollections: true
 This website is built using [Eleventy](https://11ty.dev) and hosted on
 [Netlify](https://netlify.com). It loads no client-side JavaScript, and
 currently gets a perfect score on
-[pagespeed.web.dev](https://pagespeed.web.dev).
+[pagespeed.web.dev](https://pagespeed.web.dev). (Hopefully I can keep it that
+way as I add features!)
 
 Some other resources I used as part of this site:
 

--- a/src/en/colophon.md
+++ b/src/en/colophon.md
@@ -8,8 +8,7 @@ eleventyExcludeFromCollections: true
 This website is built using [Eleventy](https://11ty.dev) and hosted on
 [Netlify](https://netlify.com). It loads no client-side JavaScript, and
 currently gets a perfect score on
-[pagespeed.web.dev](https://pagespeed.web.dev). (Hopefully I can keep it that
-way as I add features!)
+[pagespeed.web.dev](https://pagespeed.web.dev).
 
 Some other resources I used as part of this site:
 


### PR DESCRIPTION
This update to the GH Actions workflow makes it skip the build and deploy if only markdown was changed in the last commit and it was not a scheduled deployment.

Note that this is not a perfect check; I could make updates in several commits that _should_ be deployed, followed by one commit that only updates markdown, and then push, and it would short-circuit. But I want to be conservative with Actions minutes, even though they are free for now, since I may decide to make my repo private at some point. We'll see.

(TBH I initially did this because I did not realize the minutes were free for public repos 😅 Woops. But it's still good to have, and helped me learn a lot about GH Actions)