### PR TITLE
Add Cloudflare Analytics

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://cloudflareinsights.com/cdn-cgi/rum; script-src 'self' https://static.cloudflareinsights.com; img-src 'self' data:;">
     <meta name="generator" content="{{ eleventy.generator }}">
     {%- if description -%}
       <meta name="description" content="{{ description | unmd }}">
@@ -54,5 +54,6 @@
         {{ content | safe }}
     </main>
     {%- include 'partials/site-footer.njk' -%}
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "6a72187972844110ba59868a8dca8e54"}'></script>
   </body>
 </html>

--- a/src/en/colophon.md
+++ b/src/en/colophon.md
@@ -6,10 +6,7 @@ eleventyExcludeFromCollections: true
 ---
 
 This website is built using [Eleventy](https://11ty.dev) and hosted on
-[Netlify](https://netlify.com). It loads no client-side JavaScript, and
-currently gets a perfect score on
-[pagespeed.web.dev](https://pagespeed.web.dev). (Hopefully I can keep it that
-way as I add features!)
+[Netlify](https://netlify.com).
 
 Some other resources I used as part of this site:
 
@@ -23,6 +20,8 @@ Some other resources I used as part of this site:
 * [Satori](https://github.com/vercel/satori) for generating OG images from HTML
   (via
   [this excellent 11ty plugin](https://www.npmjs.com/package/eleventy-plugin-og-image))
+* [Cloudflare Analytics](https://developers.cloudflare.com/analytics/web-analytics/)
+  for simple, privacy-preserving analytics.
 
 I deploy the site via a GitHub Actions workflow that builds the site daily and
 deploys it to Netlify.


### PR DESCRIPTION
I'm just adding this for now as I am trying to publish more in the Software category, so that I can see which of my articles people read and share more. Hoping to move to server-side analytics soon so that I can go back to having zero JavaScript (and a perfect Lighthouse score 🪦), but that is blocked on [moving to Cloudflare](https://github.com/tylermercer/personal-website-eleventy/tree/switch-to-cf-pages) (or paying for Netlify Analytics).