### PR TITLE
Trigger CF deploy for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,16 @@ jobs:
             echo "result=skipped" >> $GITHUB_OUTPUT
           fi
 
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
       - name: Deploy to Cloudflare Pages
         if: steps.build_site.outputs.result == 'built'
         uses: cloudflare/pages-action@v1
         with:
+          branch: ${{ steps.extract_branch.outputs.branch }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
       - main
       - switch-to-cf-pages
   workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
         id: extract_branch
 
       - name: Deploy to Cloudflare Pages
+        id: deploy
         if: steps.build_site.outputs.result == 'built'
         uses: cloudflare/pages-action@v1
         with:
@@ -58,3 +59,15 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
           directory: ./dist
+    
+      - name: Add Deploy Preview URL to Pull Request
+        if: github.event_name == 'pull_request' && github.event.action == 'opened' && steps.build_site.outputs.result == 'built'
+        run: |
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          pr_url="https://api.github.com/repos/${{ github.repository }}/issues/${pr_number}/comments"
+          pr_body="Deployed to ${{ steps.deploy.url }}"
+          curl -sSL -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"body\":\"$pr_body\"}" \
+            "$pr_url"


### PR DESCRIPTION
It should deploy to a preview deploy because the cloudflare action will detect that it is not the main branch. We'll see.