### PR TITLE
Skip `en` directory in permalinks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -91,6 +91,7 @@ module.exports = function (eleventyConfig) {
   /* Plugins */
   eleventyConfig.addPlugin(EleventyI18nPlugin, {
     defaultLanguage: "en",
+    errorMode: "never",
   });
   eleventyConfig.addPlugin(i18n, {
     translations,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -33,27 +33,6 @@ function rmDir(dirPath, removeSelf) {
     fs.rmdirSync(dirPath);
 }
 
-function localeUrl(url, languageCode) {
-  if (!url || !url.startsWith('/')) {
-    return url; // Return original URL if it's not internal
-  }
-  const engCodePattern = /^\/en\//; // Regex pattern for two-letter EN code at the beginning of the string
-  const hasEngLanguageCode = engCodePattern.test(url)
-  if (hasEngLanguageCode) {
-    // Strip language code
-    return url.substring(3)
-  }
-  else {
-    const langCodePattern = /^\/[a-z]{2}\//; // Regex pattern for two-letter language code at the beginning of the string
-    const hasLanguageCode = langCodePattern.test(url);
-    if (hasLanguageCode || !languageCode || languageCode === 'en') {
-      return url;
-    } else {
-      return `/${languageCode}${url}`;
-    }
-  }
-}
-
 module.exports = function (eleventyConfig) {
   /* Constants */
   const now = new Date();
@@ -232,17 +211,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addWatchTarget("./src/sass/");
   eleventyConfig.on('eleventy.before', () => {
     rmDir('./dist/og-images'); // empty OG directory
-  });
-
-  /* Post-Processing Transforms */
-  eleventyConfig.addTransform("addLocaleUrlFilter", function (content) {
-    if (this.inputPath.endsWith(".md")) {
-      return content.replace(/(<a\s+(?:[^>]*?\s+)?href=(["']))(.*?)(\2)/g, (match, prefix, quote, url) => {
-        const localizedUrl = localeUrl(url, this.page.lang);
-        return `${prefix}${localizedUrl}${quote}`;
-      });
-    }
-    return content;
   });
 
   return {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -91,7 +91,7 @@ module.exports = function (eleventyConfig) {
   /* Plugins */
   eleventyConfig.addPlugin(EleventyI18nPlugin, {
     defaultLanguage: "en",
-    errorMode: "never",
+    errorMode: "never", //Could be allow-fallback if not for the pagination pages.... TODO: rethink
   });
   eleventyConfig.addPlugin(i18n, {
     translations,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -145,7 +145,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter('byLang', function (collection, lang = this.page.lang) {
     return collection.filter(item => item.data.lang === lang);
   });
-  eleventyConfig.addFilter("strip_default_locale", (path) => {
+  eleventyConfig.addFilter("stripDefaultLocale", (path) => {
     return path?.startsWith('/en') ? path.substring(3) : path;
   });
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -15,7 +15,7 @@
 
 # Serve localized content from their respective paths without redirection
 /es/* /es/:splat 200
-/en/* /en/:splat 200
+/en/* /:splat 200
 
 # Redirect any non-localized path to English version
-/* /en/:splat 200
+/* /:splat 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -13,9 +13,6 @@
 # Post redirects
 /posts/faith/explicability-agency-and-forgiveness/ /posts/faith/explicability-does-not-negate-agency/ 301
 
-# Serve localized content from their respective paths without redirection
+# Serve localized content from their respective locations
 /es/* /es/:splat 200
 /en/* /:splat 200
-
-# Redirect any non-localized path to English version
-/* /:splat 200

--- a/src/_includes/layouts/collection.njk
+++ b/src/_includes/layouts/collection.njk
@@ -9,7 +9,7 @@
         reverse: true,
         alias: "paginatedPosts",
     },
-    permalink: "{{ page.filePathStem | trimTrailingIndex }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html"
+    "override:permalink": "{{ page.filePathStem | trimTrailingIndex }}/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html"
 }
 ---
 <ul class="post-cards-list">

--- a/src/_includes/layouts/feeds/json.njk
+++ b/src/_includes/layouts/feeds/json.njk
@@ -14,7 +14,7 @@ eleventyExcludeFromCollections: true
 	},
 	"items": [
 		{%- for post in collections.posts | byLang | reverse %}
-		{%- set absolutePostUrl = post.url | strip_default_locale | htmlBaseUrl(metadata.url) %}
+		{%- set absolutePostUrl = post.url | stripDefaultLocale | htmlBaseUrl(metadata.url) %}
 		{
 			"id": "{{ absolutePostUrl }}",
 			"url": "{{ absolutePostUrl }}",

--- a/src/_includes/layouts/feeds/rss.njk
+++ b/src/_includes/layouts/feeds/rss.njk
@@ -14,7 +14,7 @@ eleventyExcludeFromCollections: true
 		{# <email>{{ metadata.author.email }}</email> #}
 	</author>
 	{%- for post in collections.posts | byLang | reverse %}
-	{% set absolutePostUrl %}{{ post.url | strip_default_locale | htmlBaseUrl(metadata.url) }}{% endset %}
+	{% set absolutePostUrl %}{{ post.url | stripDefaultLocale | htmlBaseUrl(metadata.url) }}{% endset %}
 	<entry>
 		<title>{{ post.data.title }}</title>
 		<link href="{{ absolutePostUrl }}"/>

--- a/src/_includes/partials/share-links.njk
+++ b/src/_includes/partials/share-links.njk
@@ -2,7 +2,7 @@
     <label id="share-links-label">Share this article:</label>
     <ul class="share-links-list">
         {%- set links = [ 'Facebook', 'Twitter', 'LinkedIn', 'Email' ] -%}
-        {%- set absolutePostUrl -%}{{- safeUrl | strip_default_locale | htmlBaseUrl(metadata.url) -}}{%- endset -%}
+        {%- set absolutePostUrl -%}{{- safeUrl | stripDefaultLocale | htmlBaseUrl(metadata.url) -}}{%- endset -%}
 	    {%- for link in links -%}
         {%- if loop.index === links.length -%}&nbsp;{% else %} {% endif -%}
         <li><a href="{% shareLink link, absolutePostUrl, title %}" target="_blank">

--- a/src/en/en.11tydata.js
+++ b/src/en/en.11tydata.js
@@ -1,0 +1,13 @@
+const stripDefaultLocale = (path) => {
+    return path?.startsWith('/en') ? path.substring(3) : path;
+}
+
+const trimTrailingIndex = (path) => {
+    return path?.endsWith('/index') ? path.slice(0, -6) : path;
+}
+
+module.exports = {
+    lang:"en",
+    dir:"ltr",
+    permalink: data => `${trimTrailingIndex(stripDefaultLocale(data.page.filePathStem))}${data.pagination?.pageNumber > 0 ? '/' + data.pagination.pageNumber : ''}/index.html`
+}

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -1,5 +1,0 @@
-{
-    "lang":"en",
-    "dir":"ltr",
-    "permalink":"{{ page.filePathStem | stripDefaultLocale }}/index.html"
-}

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -1,4 +1,5 @@
 {
     "lang":"en",
-    "dir":"ltr"
+    "dir":"ltr",
+    "permalink":"{{ page.filePathStem | stripDefaultLocale }}/index.html"
 }


### PR DESCRIPTION
This does three things:
* Computes a new permalink in `en` that removes that segment from the path
* Updates the redirects to respect the now-simpler content locations
* Removes the now-unnecessary HTML transform applied to all pages after rendering