### PR TITLE
Abstract out CF domain in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,6 @@ jobs:
 
             | Name                    | Result |
             | ----------------------- | - |
-            | **Preview URL**:        | https://${{ steps.extract_vars.outputs.branch }}.tylermercer.pages.dev |
+            | **Preview URL**:        | https://${{ steps.extract_vars.outputs.branch }}.${{ secrets.CLOUDFLARE_PROJECT_NAME }}.pages.dev |
             | **Last commit:**        | `${{ steps.extract_vars.outputs.sha_short }}` |
             | **Deployed at**:        | `${{ steps.extract_vars.outputs.datetime }}` |


### PR DESCRIPTION
This makes it easy for others to use the same workflow, provided they set the necessary secrets on their own repo.